### PR TITLE
use official template parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1928,6 +1928,11 @@
       "integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
       "dev": true
     },
+    "de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0="
+    },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
@@ -9319,6 +9324,15 @@
         "resolve": "1.3.3",
         "serialize-javascript": "1.3.0",
         "source-map": "0.5.6"
+      }
+    },
+    "vue-template-compiler": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.3.4.tgz",
+      "integrity": "sha512-GezvHn6bw053zIo0TQIjimRpyELjCEOrc5hGHtHUeadbVSdKB9yqY6By9WiYvbFwOZiuMmFpSfjD8VzVibWGtQ==",
+      "requires": {
+        "de-indent": "1.0.2",
+        "he": "1.1.1"
       }
     },
     "walker": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "string-hash": "^1.1.3",
     "vue": "^2.3.4",
     "vue-server-renderer": "^2.3.4",
+    "vue-template-compiler": "^2.3.4",
     "xss": "^0.3.3"
   }
 }

--- a/src/parser/script.js
+++ b/src/parser/script.js
@@ -7,7 +7,13 @@ const Utils = require('../utils');
 const babel = require('babel-core');
 const stringHash = require('string-hash');
 
-const scriptRegex = /(<script.*?>)([\s\S]*?)(<\/script>)/gm;
+type ScriptObjectType = {
+    type: 'string',
+    content: 'string',
+    start: number,
+    attrs: Object,
+    end: number
+ }
 
 function dataMerge(script: Object, defaults: Object, type: string): Object {
     let finalScript = {};
@@ -24,37 +30,29 @@ function dataMerge(script: Object, defaults: Object, type: string): Object {
     return finalScript;
 }
 
-function scriptParser(script: string, defaults: Object, type: string, regex: RegExp): Promise<string> {
+function scriptParser(scriptObject: ScriptObjectType, defaults: Object, type: string): Promise<string> {
     return new Promise((resolve, reject) => {
-        if (!regex) {
-            regex = scriptRegex;
-        }
-        if (!script) {
+        if (!scriptObject && !scriptObject.content) {
             reject(new Error('Missing Script block'));
-        }
-        const options = {
-            'presets': ['es2015']
-        };
-        const scriptArray = script.match(regex) || [];
-        if (scriptArray.length === 0) {
-            let error = `I had an error processing this script.\n${script}`;
-            reject(new Error(error));
-        }
-        let scriptString = scriptArray[0].replace(regex, '$2');
-        // caching for babel script string so time spent in babel is reduced
-        let babelScript = '';
-        const cachedBabelScript = defaults.cache.get(stringHash(scriptString));
-        if (cachedBabelScript) {
-            babelScript = cachedBabelScript;
         } else {
-            babelScript = babel.transform(scriptString, options);
-            // set the cache for the babel script string
-            defaults.cache.set(stringHash(scriptString), babelScript);
-        }
+            const options = {
+                'presets': ['es2015']
+            };
+            // caching for babel script string so time spent in babel is reduced
+            let babelScript = '';
+            const cachedBabelScript = defaults.cache.get(stringHash(scriptObject.content));
+            if (cachedBabelScript) {
+                babelScript = cachedBabelScript;
+            } else {
+                babelScript = babel.transform(scriptObject.content, options);
+                // set the cache for the babel script string
+                defaults.cache.set(stringHash(scriptObject.content), babelScript);
+            }
 
-        let evalScript = Utils.requireFromString(babelScript.code).exports;
-        let finalScript = dataMerge(evalScript.default, defaults, type);
-        resolve(finalScript);
+            let evalScript = Utils.requireFromString(babelScript.code).exports;
+            let finalScript = dataMerge(evalScript.default, defaults, type);
+            resolve(finalScript);
+        }
     });
 }
 

--- a/src/parser/style.js
+++ b/src/parser/style.js
@@ -1,30 +1,28 @@
 // @flow
 const CleanCSS = require('clean-css');
 
-const styleRegex = /(<style.*?>)([\s\S]*?)(<\/style>)/gm;
+type StyleObjectType = {
+    type: 'string',
+    content: 'string',
+    start: number,
+    attrs: Object,
+    lang: { lang: string },
+    end: number
+ }
 
-function styleParser(template: string, regex: RegExp): Promise<string> {
+function styleParser(styleObjectArray: StyleObjectType[]): Promise<string> {
     return new Promise((resolve, reject) => {
-        if (!regex) {
-            regex = styleRegex;
-        }
-        if (!template) {
+        if (!styleObjectArray && styleObjectArray.length === 0) {
             reject(new Error('missing style section'));
-        }
-        const styleArray = template.match(regex) || [];
-        let styleString  = styleArray[0];
-        let finalStyleString = '';
-        if (styleString) {
-            finalStyleString = styleString.replace(regex, '$2');
-
-            const templateLang = styleString.replace(regex, '$1');
-            if(templateLang.includes('lang="scss"') || templateLang.includes('lang="less"')) {
-                console.error('Sorry please only use plain CSS in your files for now');
+        } else {
+            for (const styleObject of styleObjectArray) {
+                if(styleObject.lang === 'scss' || styleObject.lang === 'less') {
+                    console.error('Sorry please only use plain CSS in your files for now');
+                }
+                const output = new CleanCSS({}).minify(styleObject.content);
+                resolve(output.styles);
             }
         }
-        const options = {};
-        const output = new CleanCSS(options).minify(finalStyleString);
-        resolve(output.styles);
     });
 }
 


### PR DESCRIPTION
fixes #20 

slightly slower than our regexes but much safer. We should move the cache to the object rather than the string.. save on re-running the same object parsing

```all scenarios completed
Complete report @ 2017-07-12T12:44:39.597Z
  Scenarios launched:  2000
  Scenarios completed: 2000
  Requests completed:  20000
  RPS sent: 765.7
  Request latency:
    min: 38.2
    max: 1780.5
    median: 481.1
    p95: 947.2
    p99: 1316
  Scenario duration:
    min: 685.2
    max: 7967.2
    median: 5347.6
    p95: 7801.8
    p99: 7913
  Scenario counts:
    0: 2000 (100%)
  Codes:
    200: 20000```
