### PR TITLE
fix for styleparser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "express-vue-renderer",
-    "version": "0.6.4",
+    "version": "0.6.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/parser/style.js
+++ b/src/parser/style.js
@@ -11,9 +11,9 @@ type StyleObjectType = {
  }
 
 function styleParser(styleObjectArray: StyleObjectType[]): Promise<string> {
-    return new Promise((resolve, reject) => {
-        if (!styleObjectArray && styleObjectArray.length === 0) {
-            reject(new Error('missing style section'));
+    return new Promise((resolve) => {
+        if (!styleObjectArray || styleObjectArray.length === 0) {
+            resolve('');
         } else {
             for (const styleObject of styleObjectArray) {
                 if(styleObject.lang === 'scss' || styleObject.lang === 'less') {


### PR DESCRIPTION
Styleblock missing had uncaught exception

so if theres no style block, then resolve with empty string.